### PR TITLE
We must become more dynamic, introducing the QueryLoaderQueryLoader

### DIFF
--- a/src/QueryLoader/QueryLoaderQueryLoader.php
+++ b/src/QueryLoader/QueryLoaderQueryLoader.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * This file is part of cocur/nqm.
+ *
+ * (c) Florian Eckerstorfer <florian@eckerstorfer.co>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * whatever
+ */
+
+namespace Cocur\NQM\QueryLoader;
+
+use Cocur\NQM\Exception\QueryNotExistsException;
+use PDO;
+
+/**
+ * Load queries from the query loader.
+ *
+ * @package    cocur/nqm
+ * @subpackage queryloader
+ * @author     Florian Eckerstorfer <florian@eckerstorfer.co>
+ * @copyright  2013 Florian Eckerstorfer
+ * @license    http://opensource.org/licenses/MIT The MIT License
+ *
+ * whatever
+ */
+class QueryLoaderQueryLoader implements QueryLoaderInterface
+{
+    const HAS_QUERY_META_QUERY_NAME = 'has-query-meta-query';
+    const GET_QUERY_META_QUERY_NAME = 'get-query-meta-query';
+
+    /** @var PDO */
+    private $pdo;
+
+    /** @var QueryLoaderInterface */
+    private $loader;
+
+    /**
+     * Constructor.
+     *
+     * It constructs the objects. And initializes the initial state. And takes some
+     * constructor arguments that are then assigned to properties. So that they can
+     * be accessed by other methods later on.
+     *
+     * @param PDO The database thing that does the execution?
+     * @param QueryLoaderInterface $loader The loader. It loads queries. For the query loader.
+     */
+    public function __construct(PDO $pdo, QueryLoaderInterface $loader = null)
+    {
+        $this->pdo = $pdo;
+        $this->loader = $loader;
+    }
+
+    /**
+     * Sets the loader.
+     *
+     * @param QueryLoaderInterface $loader The loader.
+     *
+     * @return QueryLoaderQueryLoader
+     */
+    public function setLoader($loader)
+    {
+        $this->loader = $loader;
+
+        return $this;
+    }
+
+    /**
+     * Returns the loader.
+     *
+     * @return QueryLoaderInterface $loader The loader. It loads queries. For the query loader.
+     */
+    public function getLoader()
+    {
+        return $this->loader;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasQuery($name)
+    {
+        $metaQuery = $this->loader->getQuery(static::HAS_QUERY_META_QUERY_NAME);
+        $stmt = $this->pdo->prepare($metaQuery);
+        $stmt->execute(':name' => $name);
+
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return (bool) $row['count'];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getQuery($name)
+    {
+        $metaQuery = $this->loader->getQuery(static::GET_QUERY_META_QUERY_NAME);
+        $stmt = $this->pdo->prepare($metaQuery);
+        $stmt->execute(':name' => $name);
+
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row['query'];
+    }
+}


### PR DESCRIPTION
Hello,

I found this project quite delightful indeed. It has some quite remarkable features. However, one limiting factor when running this in a distributed manner, is that there is no central place to store the queries in a consistent and reliable way. The obvious solution is to use an SQL database for storing the queries.

Introducing, the QueryLoaderQueryLoader. It loads its own queries from a different query loader, then executes those queries on a query that you can define. This allows queries to be swapped in an atomic manner across the entire system, simply by updating a row in the table. It also allows for rapid iteration and on-the-fly adjustments without having to re-deploy code or config files.

You must pass it a QueryLoader from which it will load the queries for fetching the requested queries. This query loader has a strictly defined interface of two queries, that have the following signatures:
- **has-query-meta-query** this is the query that returns the query for checking if a query of a certain name exists. The query stored there takes one `:name` parameter as an input, and must return a row with a `count` field, indicating whether the name exists.
- **get-query-meta-query** this is the query that returns the query for fetching a query by name. The query stored there takes one `:name` parameter as input and must return a row with a `query` field, containing the query that the user requested by name.

For basic usage, just pass `$pdo` and `$loader` arguments to the constructor:

```
$pdo = new PDO(...);
$metaQueryLoader = new FilesystemQueryLoader('meta-queries');
$queryLoader = new QueryLoaderQueryLoader($pdo, $metaQueryLoader);

$nqm = NQM($pdo, $queryLoader);
$nqm->...();
```

However, it becomes more interesting when you pass the QueryLoaderQueryLoader to itself:

```
$queryLoader = new QueryLoaderQueryLoader($pdo);
$queryLoader->setLoader($queryLoader);
```

This will put the query loader into a special mode where the CPU goes round and computes the maximum stack size of the PHP interpreter.

PS: I didn't really test this code, but I'm pretty sure it works. I wrote something similar once and it worked too. Either way, really excited about this node query manager!
